### PR TITLE
TRIB-269: refactors path characters to File.separator for cross platform compatibility 

### DIFF
--- a/src/main/java/com/savvato/basemobileapp/services/ResourceTypeServiceImpl.java
+++ b/src/main/java/com/savvato/basemobileapp/services/ResourceTypeServiceImpl.java
@@ -4,6 +4,8 @@ import com.savvato.basemobileapp.constants.ResourceTypeConstants;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
+import java.io.File;
+
 @Service
 public class ResourceTypeServiceImpl implements ResourceTypeService {
 
@@ -14,7 +16,7 @@ public class ResourceTypeServiceImpl implements ResourceTypeService {
         String rtn = null;
 
         if (resourceType.equals(ResourceTypeConstants.RESOURCE_TYPE_PROFILE_IMAGE)) {
-            rtn = resourcesDirRoot + "/profile";
+            rtn = resourcesDirRoot + File.separator + "profile";
         } else {
             throw new IllegalArgumentException("ResourceTypeService was passed an invalid resource type.");
         }

--- a/src/main/java/com/savvato/basemobileapp/services/StorageService.java
+++ b/src/main/java/com/savvato/basemobileapp/services/StorageService.java
@@ -26,7 +26,7 @@ public class StorageService {
 	public void store(String resourceType, MultipartFile file, String filename) {
     	String dir = resourceTypeService.getDirectoryForResourceType(resourceType);
 
-		log.debug("******* ****  **** about to do StorageService::store() " + dir + "/" + filename);
+		log.debug("******* ****  **** about to do StorageService::store() " + dir + File.separator + filename);
 
     	try {
     		File fdir = new File(dir);
@@ -36,7 +36,7 @@ public class StorageService {
     	}
 
     	try {
-			file.transferTo(new File(dir + "/" + filename));
+			file.transferTo(new File(dir + File.separator + filename));
 		} catch (IllegalStateException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
@@ -45,7 +45,7 @@ public class StorageService {
 			e.printStackTrace();
 		}
 
-    	log.debug("*********     *** successfully exiting the store method .. " + dir + "/" + filename);
+    	log.debug("*********     *** successfully exiting the store method .. " + dir + File.separator + filename);
     }
 
 //    public Resource loadAsResource(String resourceType, String filename) {
@@ -79,7 +79,7 @@ public class StorageService {
 		String dir = resourceTypeService.getDirectoryForResourceType(resourceType);
 
     	try {
-    		File f = new File(dir + "/" + filename);
+    		File f = new File(dir + File.separator + filename);
 
 			if (f.exists())
 				rtn = f.lastModified();
@@ -88,7 +88,7 @@ public class StorageService {
     		throw e;
 		}
     	
-    	log.debug("***************}}  checking isFound: " + dir + "/" + filename + " --> " + rtn + " " + (rtn != 0));
+    	log.debug("***************}}  checking isFound: " + dir + File.separator + filename + " --> " + rtn + " " + (rtn != 0));
     	
     	return rtn;
     }
@@ -97,10 +97,10 @@ public class StorageService {
     	boolean rtn = false;
 		String dir = resourceTypeService.getDirectoryForResourceType(resourceType);
 
-		log.debug("***************}}  Deleting: " + dir + "/" + filename);
+		log.debug("***************}}  Deleting: " + dir + File.separator + filename);
 
 		try {
-    		File f = new File(dir + "/" + filename);
+    		File f = new File(dir + File.separator + filename);
     		rtn = f.delete();
     	} catch (Exception e) {
     		throw e;
@@ -112,13 +112,13 @@ public class StorageService {
 
     public byte[] loadAsByteArray(String resourceType, String filename) {
 		String dir = resourceTypeService.getDirectoryForResourceType(resourceType);
-    	log.debug("*******         Returning byte array of file at: " + dir + "/" + filename);
+    	log.debug("*******         Returning byte array of file at: " + dir + File.separator + filename);
 
     	byte[] rtn = null;
     
 	    try {
 	    	// try to load the requested image
-	    	rtn = readFile(new FileSystemResource(dir + "/" + filename));
+	    	rtn = readFile(new FileSystemResource(dir + File.separator + filename));
 	    } catch (FileNotFoundException fnfe) {
 //	    	try {
 //	    		 if it can't be found, send back our default image
@@ -127,10 +127,10 @@ public class StorageService {
 //	    	} catch (IOException ioe) {
 //	    		log.error(ioe);
 //	    	}
-			log.error("Could not find file: " + dir + "/" + filename);
+			log.error("Could not find file: " + dir + File.separator + filename);
 	    } catch (IOException ioe) {
 	    	// something other than a missing requested file happened.. :(
-	    	log.error("Something bad happened with the file " + dir + "/" + filename, ioe);
+	    	log.error("Something bad happened with the file " + dir + File.separator + filename, ioe);
 	    }
 	    
 	    return rtn;


### PR DESCRIPTION
- updated all references for literal path "/" to File.seperator in StorageService, ResourceTypeService
   - note: this does not include commented out code, of which there is a lot. The commented out code does not run and therefore could not be tested and confirmed with this change. I left it as is.

TESTING
Successfully ran front end and back end and changed a profile picture on Mac and Windows environments